### PR TITLE
Sets the default number of rsa bits to 3072

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,8 @@ data ibm_resource_group resource_group {
 resource tls_private_key generated_key {
   count = !local.keys_provided ? 1 : 0
 
-  algorithm   = "RSA"
+  algorithm = "RSA"
+  rsa_bits  = var.rsa_bits
 }
 
 resource ibm_is_ssh_key key {

--- a/variables.tf
+++ b/variables.tf
@@ -43,3 +43,9 @@ variable "private_key" {
   description = "(Optional) The public key provided for the ssh key. If not provided it will be generated"
   default     = ""
 }
+
+variable "rsa_bits" {
+  type        = number
+  description = "The number of bits for the generated rsa key"
+  default     = 3072
+}


### PR DESCRIPTION
Signed-off-by: Sean Sundberg <seansund@us.ibm.com>